### PR TITLE
Adapted to some (newer) CRAN style rules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: BayesLogit
-Version: 2.1
-Date: 2019-09-25
+Version: 2.2
+Date: 2025-06-27
 Title: PolyaGamma Sampling
 Authors@R: c(
     person("Nicholas G.", "Polson", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,9 @@
-# June 27, 2025
+# BayesLogit 2.2 (2025-06-27)
 
 - Minor edits to comply with CRAN NOTEs in CITATION.
 - Minor edits to NEWS.md to avoid CRAN NOTE about NEWS.md.
 
-# September 25, 2019
+# BayesLogit 2.1 (2019-09-25)
 
 - BayesLogit has been completely re-organized. Previously, the package was
   derived from a repository used for a doctoral thesis, and included many

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,16 @@
+# June 27, 2025
+
+- Minor edits to comply with CRAN NOTEs in CITATION.
+- Minor edits to NEWS.md to avoid CRAN NOTE about NEWS.md.
+
 # September 25, 2019
 
-BayesLogit has been completely re-organized. Previously, the package was derived
-from a repository used for a doctoral thesis, and included many items beyond
-what was necessary for an R package. This made the subsequent package difficult
-to maintain.
-
-The new package and repository (<https://github.com/jwindle/BayesLogit>) has
-been slimmed down and now is focused on implementation of PolyaGamma sampling
-methods.
-
-Thanks go to Jari Oksanen and James Balamuta for their help in getting the
-package ready for CRAN. 
+- BayesLogit has been completely re-organized. Previously, the package was
+  derived from a repository used for a doctoral thesis, and included many
+  items beyond what was necessary for an R package. This made the
+  subsequent package difficult to maintain.
+  The new package and repository (<https://github.com/jwindle/BayesLogit>)
+  has been slimmed down and now is focused on implementation of PolyaGamma
+  sampling methods.
+  Thanks go to Jari Oksanen and James Balamuta for their help in getting
+  thepackage ready for CRAN. 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ An updated version of the R Package BayesLogit.  This version reduces the
 package down to its core functionality: sampling from the PolyaGamma
 distribution.  View the sampling routine documentation via `?rpg`.
 
-The original `BayesLogit` package source can be found here:
-
-<https://github.com/jwindle/BayesLogit-Thesis>
-
 Check out the latest [news](NEWS.md).
 
 ## License

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,10 +1,9 @@
-citHeader("To cite package 'BayesLogit' in publications use:")
-
-citEntry(entry = "Unpublished",
+bibentry(bibtype = "Unpublished",
+  header = "To cite package 'BayesLogit' in publications use:",
   title  = "Bayesian inference for logistic models using Polya-Gamma latent variables",
-  author = personList(as.person("Nicholas G. Polson"),
-                      as.person("James G. Scott"),
-                      as.person("Jesse Windle")),
+  author = c(person(given = "Nicholas G.", family = "Polson"),
+             person(given = "James G.", family = "Scott"),
+             person(given = "Jesse", family = "Windle")),
   year   = 2013,
   url    = "http://arxiv.org/abs/1205.0310",
   note   = "Most recent version: Feb. 2013.",


### PR DESCRIPTION
This fixes:
- CRAN NOTE about citeEntry -> bibentry
- CRAN NOTE about personList -> c(person(),...)
- CRAN NOTE about NEWS.md noncompliance
- CRAN NOTE about dead link to old repo

This does not fix:
- CRAN false positive NOTE (testing version only) about functions which look like S3 generics (but aren't even exported). It is quite possible that you may get through without addressing this at the moment, as these errors do not currently show up on the CRAN page itself.

I have also include a version bump to 2.2 to make this as ready as possible to be CRAN ready. The build was tested on Linux, Mac, and WinBuilder.